### PR TITLE
allow shell to display qr code if apps don't do their own display

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ def register_skill(self):
         "token_endpoint": token_endpoint, #Required
         "refresh_endpoint": "", #Optional - Some apps may require this
         "scope": "", #Optional - Some apps may require this
-        "shell_integration": False #Optional - mark as false if app/skill handles displaying generated QR code. mark as true if shell should handle it.
+        "shell_integration": True #Optional - mark as false if app/skill handles displaying generated QR code. mark as true if shell should handle it.
     }))
 
 def start_qr_generation(self):

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ def register_skill(self):
         "token_endpoint": token_endpoint, #Required
         "refresh_endpoint": "", #Optional - Some apps may require this
         "scope": "", #Optional - Some apps may require this
-        "shell_integration": False #Optional - mark this as true if you want the shell to display generated QR code, mark as false if app handles displaying generated QR code.
+        "shell_integration": False #Optional - mark as false if app/skill handles displaying generated QR code. mark as true if shell should handle it.
     }))
 
 def start_qr_generation(self):

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ def register_skill(self):
         "auth_endpoint": auth_endpoint, #Required
         "token_endpoint": token_endpoint, #Required
         "refresh_endpoint": "", #Optional - Some apps may require this
-        "scope": "" #Optional - Some apps may require this
+        "scope": "", #Optional - Some apps may require this
+        "shell_integration": False #Optional - mark this as true if you want the shell to display generated QR code, mark as false if app handles displaying generated QR code.
     }))
 
 def start_qr_generation(self):

--- a/ovos_PHAL_plugin_oauth/__init__.py
+++ b/ovos_PHAL_plugin_oauth/__init__.py
@@ -229,7 +229,7 @@ class OAuthPlugin(PHALPlugin):
         }))
 
         # display the code in shell if registed app wants
-        display_code_on_shell = data.get("shell_integration")
+        display_code_on_shell = data.get("shell_integration", True)
         if display_code_on_shell:
             self.bus.emit(message("ovos.shell.oauth.display.qr.code", {
                 "skill_id": skill_id,

--- a/ovos_PHAL_plugin_oauth/__init__.py
+++ b/ovos_PHAL_plugin_oauth/__init__.py
@@ -143,11 +143,11 @@ class OAuthPlugin(PHALPlugin):
         client_id = message.data.get("client_id")
         client_secret = message.data.get("client_secret")
 
-        # For QR code based authentication, some skills/plugins might not
-        # have any QML UI to display the code to scan
-        # Skills / apps can mark this as true at registeration
-        # if they need shell to display the QR code once generated
-        shell_display = message.data.get("shell_integration", False)
+        # For QR code based authentication, some skills/plugins might
+        # have their own UI and QML flow to display the code
+        # Skills / apps can mark this as false at registeration
+        # if they want to handle the display
+        shell_display = message.data.get("shell_integration", True)
 
         with OAuthApplicationDatabase() as db:
             db.add_application(oauth_service=munged_id,

--- a/ovos_PHAL_plugin_oauth/__init__.py
+++ b/ovos_PHAL_plugin_oauth/__init__.py
@@ -231,7 +231,7 @@ class OAuthPlugin(PHALPlugin):
         # display the code in shell if registed app wants
         display_code_on_shell = data.get("shell_integration", True)
         if display_code_on_shell:
-            self.bus.emit(message("ovos.shell.oauth.display.qr.code", {
+            self.bus.emit(Message("ovos.shell.oauth.display.qr.code", {
                 "skill_id": skill_id,
                 "app_id": app_id,
                 "qr": qr_code

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ovos-backend-client~=0.0, >=0.0.6a10
+ovos-backend-client>=0.0.6a11
 Flask>=0.12
 oauthlib~=3.0
 qrcode~=7.3.1


### PR DESCRIPTION
- Allow shell to display QR code once it is generated for skills, apps and plugins that do not have their own QML UI and are part of other frameworks, example OCP skills
- Skills, Apps can simply mark shell_integration as true during registration and once the QR is generated it will be displayed then by the shell