### PR TITLE
Refresh token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# vim cache files
+.*.sw?

--- a/ovos_PHAL_plugin_oauth/__init__.py
+++ b/ovos_PHAL_plugin_oauth/__init__.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+import time
 import uuid
 
 import qrcode
@@ -58,6 +59,11 @@ def oauth_callback(munged_id):
         ).json()
 
     with OAuthTokenDatabase() as db:
+        # Make sure expires_at entry exists
+        if 'expires_at' not in token_response:
+            token_response['expires_at'] = (
+                    time.time() + token_response['expires_in']
+            )
         db.add_token(munged_id, token_response)
 
     # Allow any registered app / skill to handle the token response urgently, if needed


### PR DESCRIPTION
The "oauth.refresh" message is now handled and will trigger a token
refresh if possible. The Message data must contain valid "skill_id" and
"app_id" fields.

It also adds a basic "expires_at" entry to the token data to help determining if a token needs to be renewed.