### PR TITLE
move oauth utils to ovos-utils and deprecate backend-client

### DIFF
--- a/ovos_PHAL_plugin_oauth/__init__.py
+++ b/ovos_PHAL_plugin_oauth/__init__.py
@@ -7,8 +7,7 @@ import qrcode
 import requests
 from flask import Flask, request
 from oauthlib.oauth2 import WebApplicationClient
-from ovos_backend_client.database import (OAuthApplicationDatabase,
-                                          OAuthTokenDatabase)
+from ovos_utils.oauth import OAuthApplicationDatabase, OAuthTokenDatabase
 from ovos_bus_client.message import Message
 from ovos_plugin_manager.phal import PHALPlugin
 from ovos_utils import classproperty

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ovos-utils>=0.0.26,<1.0.0
+ovos-utils>=0.4.1,<1.0.0
 ovos-bus-client>=0.0.3,<2.0.0
 Flask>=0.12
 oauthlib~=3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-ovos-backend-client>=0.2.0,<2.0.0
 ovos-utils>=0.0.26,<1.0.0
 ovos-bus-client>=0.0.3,<2.0.0
 Flask>=0.12


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved error handling for OAuth registration and QR code generation processes.
  
- **Bug Fixes**
	- Streamlined token response handling by ensuring the presence of the `expires_at` field.

- **Chores**
	- Updated version specification for the `ovos-utils` package in `requirements.txt`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->