### PR TITLE
fix(deps): allow ovos-bus-client 2.x (widen cap to <3.0.0)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ovos-utils>=0.4.1,<1.0.0
-ovos-bus-client>=0.0.3,<2.0.0
+ovos-bus-client>=0.0.3,<3.0.0
 Flask>=0.12
 oauthlib~=3.0
 qrcode[pil]~=7.3.1


### PR DESCRIPTION
ovos-bus-client 2.x dropped only the bundled hivemind protocol + messagebus solver (#207) — no API break (#215). Widen `<2.0.0`→`<3.0.0` (1.x stays default). Stack-wide migration for HiveMind 2.x adoption.